### PR TITLE
Refactor import module to be more adherent to Blenderbim

### DIFF
--- a/bb_import.py
+++ b/bb_import.py
@@ -103,6 +103,7 @@ class IfcImporter():
         self.project["freecad"].FilePath = self.filename
         self.project["freecad"].Proxy.ifcfile = self.ifc_file
         self.project["freecad"].addExtension("App::GroupExtensionPython")
+        self.project["freecad"].ViewObject.addExtension('Gui::ViewProviderGroupExtensionPython')
         self.add_properties(self.ifc_file.by_type("IfcProject")[0], self.project["freecad"])
 
     def create_collections(self):
@@ -128,6 +129,7 @@ class IfcImporter():
             global_id = element.GlobalId
             collection = self.create_fc_object_from_ifc_entity(element)
             collection.addExtension("App::GroupExtensionPython") # TODO: Check if is more adherent to use geofeature group extension
+            collection.ViewObject.addExtension('Gui::ViewProviderGroupExtensionPython')
             #self.collections[global_id] = collection
             parent.addObject(collection)
             if element.IsDecomposedBy:

--- a/bb_objects/bb_object.py
+++ b/bb_objects/bb_object.py
@@ -43,3 +43,7 @@ class bb_object:
             shapes.append(siteshape)
         if shapes:
             obj.Shape = Part.makeCompound(shapes)
+
+    def get_corresponding_ifc_element(self):
+        #TODO: To be implemented
+        pass

--- a/bb_viewproviders/bb_vp_object.py
+++ b/bb_viewproviders/bb_vp_object.py
@@ -53,32 +53,6 @@ class bb_vp_object:
     def getIcon(self):
         return os.path.join(os.path.dirname(os.path.dirname(__file__)),"icons","IFC_object.svg")
 
-    def claimChildren(self):
-
-        #TODO refactor / use group extension
-
-        children = []
-        relprops = ["Item","ForLayerSet"] # properties that actually store parents
-        for prop in self.Object.PropertiesList:
-            if prop.startswith("Relating") or (prop in relprops):
-                continue
-            else:
-                value = getattr(self.Object, prop)
-                if hasattr(value, "ViewObject"):
-                    children.append(value)
-                elif isinstance(value, list):
-                    for item in value:
-                        if hasattr(item, "ViewObject"):
-                            children.append(item)
-        for parent in self.Object.InList:
-            for prop in parent.PropertiesList:
-                if prop.startswith("Relating") or (prop in relprops):
-                    value = getattr(parent, prop)
-                    if value == self.Object:
-                        children.append(parent)
-        return children
-
-
     def setupContextMenu(self, vobj, menu):
 
         from PySide2 import QtCore, QtGui, QtWidgets # lazy import


### PR DESCRIPTION
Just playing a bit with the module to understand how it works and try to change it to be more similar to blenderbim importer so we can benefit of the blenderbim improvements.
@yorikvanhavre feel free to close the PR it if it's too annoying to have the code refactored as soon as it was written :)

PS It still need more work, but i wanted to share it cause i won't have time till next weekend to work on it.

PS Also used more modern object creation: 
`document.addObject('Part::FeaturePython', 'IfcDocument', bb_object.bb_object(), bb_vp_document.bb_vp_document(), False) `
