### PR TITLE
bb_object: add method to get the corrisponding Ifc object

### DIFF
--- a/bb_objects/bb_object.py
+++ b/bb_objects/bb_object.py
@@ -43,3 +43,10 @@ class bb_object:
             shapes.append(siteshape)
         if shapes:
             obj.Shape = Part.makeCompound(shapes)
+
+    def get_corresponding_ifc_element(self, obj):
+        import bb_import
+        ifc_file = bb_import.get_ifcfile(obj)
+        if ifc_file and hasattr(obj, "StepId"):
+            return ifc_file.by_id(obj.StepId)
+        return None


### PR DESCRIPTION
Added a method to the object to link to the corresponding Ifc object. Still unsure about the name, if element is correct or object would be better.
Is it good to add this kind of stuff to the object? ps i'd also like to add methods to retrieve the representation contexts.